### PR TITLE
* checking migrations table exists bugfix

### DIFF
--- a/lib/domain/persister/mysql.js
+++ b/lib/domain/persister/mysql.js
@@ -12,7 +12,7 @@ try {
 
 const util = require('util')
 
-const CHECK_TABLE_SQL = 'SELECT EXISTS(SELECT * FROM information_schema.tables WHERE table_name = ?) as value'
+const CHECK_TABLE_SQL = 'SELECT EXISTS(SELECT * FROM information_schema.tables WHERE table_schema = ? AND table_name = ?) as value'
 const CREATE_TABLE_SQL = 'CREATE TABLE %s (id int, description VARCHAR(500), migrated_at DATETIME)'
 const LAST_VERSION_SQL = 'SELECT id AS value FROM %s ORDER BY id DESC LIMIT 1'
 const GET_ALL_SQL = 'SELECT id, description, migrated_at FROM %s ORDER BY id DESC'
@@ -30,7 +30,7 @@ function createMysqlPersister (client, tableName) {
 
   const commitTransaction = () => client.query('COMMIT')
 
-  const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [tableName])
+  const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [client.connection.config.database, tableName])
 
   const createTable = () =>
     client.query(util.format(CREATE_TABLE_SQL, tableName))


### PR DESCRIPTION
We need to check database name too, otherwise existing table 'migrations' in other database produce wrong script behavior.